### PR TITLE
From AnyObserver to RxCocoa.Binding

### DIFF
--- a/Sources/Kingfisher+Rx.swift
+++ b/Sources/Kingfisher+Rx.swift
@@ -46,9 +46,4 @@ extension Reactive where Base == Kingfisher<ImageView> {
     }
 }
 
-extension Kingfisher: ReactiveCompatible {
-    public var rx: Reactive<Kingfisher> {
-        get { return Reactive(self) }
-        set { }
-    }
-}
+extension Kingfisher: ReactiveCompatible { }

--- a/Sources/Kingfisher+Rx.swift
+++ b/Sources/Kingfisher+Rx.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
+import RxCocoa
 import RxSwift
 import Kingfisher
 
@@ -35,15 +36,13 @@ extension Reactive where Base == Kingfisher<ImageView> {
     }
 
     public func image(placeholder: Placeholder? = nil,
-                      options: KingfisherOptionsInfo? = nil) -> AnyObserver<Resource> {
-        return AnyObserver.init(eventHandler: { [base] e in
-            guard case .next(let resource) = e else { return }
-
-            _ = base.rx.setImage(with: resource,
-                                 placeholder: placeholder,
-                                 options: options)
-                       .subscribe()
-        })
+                      options: KingfisherOptionsInfo? = nil) -> Binder<URL?> {
+        // We pass `base.base` here since `Binder` requires a retainable object
+        return Binder(base.base) { imageView, image in
+            imageView.kf.setImage(with: image,
+                                  placeholder: placeholder,
+                                  options: options)
+        }
     }
 }
 

--- a/Sources/Kingfisher+Rx.swift
+++ b/Sources/Kingfisher+Rx.swift
@@ -37,7 +37,7 @@ extension Reactive where Base == Kingfisher<ImageView> {
 
     public func image(placeholder: Placeholder? = nil,
                       options: KingfisherOptionsInfo? = nil) -> Binder<URL?> {
-        // We pass `base.base` here since `Binder` requires a retainable object
+        // `base.base` is the `Kingfisher` class' associated `ImageView`.
         return Binder(base.base) { imageView, image in
             imageView.kf.setImage(with: image,
                                   placeholder: placeholder,


### PR DESCRIPTION
PR makes a binding implementation similar to [UIImageView extension](https://github.com/ReactiveX/RxSwift/blob/master/RxCocoa/iOS/UIImageView+Rx.swift)
The basic usage is:
```swift
viewModel
    .imageUrl
    .drive(imageView.kf.rx.image(placeholder: placeholder))
    .disposedBy(disposeBag)
```
But there is still one design issue. Since we cannot bind `Observable<URL>` to `Binding<Resource>`, the current workaround is `Binding<URL?>` return type. The other choices:
* Return `Binding<Resource?>`. The same element type as in the current version. The drawback is repeating `map { $0 as Resource? }` typecasting
* Separate `Resource` and `URL` bindings. Code duplicating