### PR TITLE
Make error public, otherwise it cannot be used outside the framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Made RxKingfisherError public
+- Made `RxKingfisherError` public.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Made RxKingfisherError public
+
 ### Removed
 
 ## [0.3.0] - 2018-10-15

--- a/Sources/RxKingfisherError.swift
+++ b/Sources/RxKingfisherError.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum RxKingfisherError: Swift.Error {
+public enum RxKingfisherError: Swift.Error {
     case kingfisherError(NSError)
     case missingImage
 }


### PR DESCRIPTION
I want to handle the image error returned by the extension, when its not public I cannot case the underlying error.