### PR TITLE
Avoid Reentrancy anomaly error.

### DIFF
--- a/Sources/KingfisherManager+Rx.swift
+++ b/Sources/KingfisherManager+Rx.swift
@@ -13,8 +13,10 @@ extension Reactive where Base == KingfisherManager {
     public func retrieveImage(with source: Source,
                               options: KingfisherOptionsInfo? = nil) -> Single<Image> {
         return Single.create { [base] single in
-            let task = base.retrieveImage(with: source,
+            var task: DownloadTask?
+            task = base.retrieveImage(with: source,
                                           options: options) { result in
+                task = nil
                 switch result {
                 case .success(let value):
                     single(.success(value.image))


### PR DESCRIPTION
A SingleEvent should be called only once.
When the `task?.cancel()` was called during a Single is disposing of, this may cause another error result about task canceled, so the SingleEvent will be called twice.

```
⚠️ Reentrancy anomaly was detected.
  > Debugging: To debug this issue you can set a breakpoint in .../RxSwift/RxSwift/Rx.swift:96 and observe the call stack.
  > Problem: This behavior is breaking the observable sequence grammar. `next (error | completed)?`
    This behavior breaks the grammar because there is overlapping between sequence events.
    Observable sequence is trying to send an event before sending of previous event has finished.
  > Interpretation: This could mean that there is some kind of unexpected cyclic dependency in your code,
    or that the system is not behaving in the expected way.
  > Remedy: If this is the expected behavior this message can be suppressed by adding `.observeOn(MainScheduler.asyncInstance)`
    or by enqueuing sequence events in some other way.
```