### PR TITLE
Only send error event if not from cancelling the task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -11,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Changed
+
+- Only emit error events that are not from canceling the task. [#21](https://github.com/RxSwiftCommunity/RxKingfisher/pull/21)
 
 ## [1.0.0] - 2019-08-07
 
@@ -28,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.5.0] - 2019-03-01
 
 ### Changed
+
 - Minimum deployment targets are now iOS 10, tvOS 10 and macOS 10.12.
 - Minimum Swift Version is 4.2.
 - RxKingfisher now works with, and requires, Kingfisher 5
@@ -41,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.2.0] - 2018-07-28
 
 ### Changed
+
 - Use `Binder` instead of `AnyObserver`.
 
 ## [0.1.1] - 2018-05-21

--- a/RxKingfisher.xcodeproj/project.pbxproj
+++ b/RxKingfisher.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		78A52EF4209EF9C6002E26D2 /* Kingfisher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78A52EF1209EF9C6002E26D2 /* Kingfisher.framework */; };
 		78A52EFE209EF9E2002E26D2 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78A52EFB209EF9E2002E26D2 /* RxSwift.framework */; };
 		78A52F00209EF9E2002E26D2 /* Kingfisher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78A52EFD209EF9E2002E26D2 /* Kingfisher.framework */; };
+		85EFD9692470DAFC000AECB3 /* KingfisherErrorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EFD9682470DAFC000AECB3 /* KingfisherErrorExtensions.swift */; };
+		85EFD96A2470DB06000AECB3 /* KingfisherErrorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EFD9682470DAFC000AECB3 /* KingfisherErrorExtensions.swift */; };
+		85EFD96B2470DB06000AECB3 /* KingfisherErrorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EFD9682470DAFC000AECB3 /* KingfisherErrorExtensions.swift */; };
 		8933C78E1EB5B82C000D00A4 /* RxKingfisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* RxKingfisherTests.swift */; };
 		8933C78F1EB5B82C000D00A4 /* RxKingfisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* RxKingfisherTests.swift */; };
 		8933C7901EB5B82D000D00A4 /* RxKingfisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* RxKingfisherTests.swift */; };
@@ -77,6 +80,7 @@
 		78A52EFB209EF9E2002E26D2 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/tvOS/RxSwift.framework; sourceTree = "<group>"; };
 		78A52EFC209EF9E2002E26D2 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/tvOS/RxCocoa.framework; sourceTree = "<group>"; };
 		78A52EFD209EF9E2002E26D2 /* Kingfisher.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kingfisher.framework; path = Carthage/Build/tvOS/Kingfisher.framework; sourceTree = "<group>"; };
+		85EFD9682470DAFC000AECB3 /* KingfisherErrorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KingfisherErrorExtensions.swift; sourceTree = "<group>"; };
 		8933C7891EB5B82A000D00A4 /* RxKingfisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxKingfisherTests.swift; sourceTree = "<group>"; };
 		AD2FAA261CD0B6D800659CF4 /* RxKingfisher.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = RxKingfisher.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* RxKingfisherTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = RxKingfisherTests.plist; sourceTree = "<group>"; };
@@ -199,6 +203,7 @@
 			children = (
 				78A52EDB209EF999002E26D2 /* Kingfisher+Rx.swift */,
 				78A52EDA209EF999002E26D2 /* KingfisherManager+Rx.swift */,
+				85EFD9682470DAFC000AECB3 /* KingfisherErrorExtensions.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -478,6 +483,7 @@
 			files = (
 				78A52EE4209EF999002E26D2 /* Kingfisher+Rx.swift in Sources */,
 				78A52EE0209EF999002E26D2 /* KingfisherManager+Rx.swift in Sources */,
+				85EFD9692470DAFC000AECB3 /* KingfisherErrorExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -495,6 +501,7 @@
 			files = (
 				78A52EE7209EF999002E26D2 /* Kingfisher+Rx.swift in Sources */,
 				78A52EE3209EF999002E26D2 /* KingfisherManager+Rx.swift in Sources */,
+				85EFD96A2470DB06000AECB3 /* KingfisherErrorExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -504,6 +511,7 @@
 			files = (
 				78A52EE5209EF999002E26D2 /* Kingfisher+Rx.swift in Sources */,
 				78A52EE1209EF999002E26D2 /* KingfisherManager+Rx.swift in Sources */,
+				85EFD96B2470DB06000AECB3 /* KingfisherErrorExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Kingfisher+Rx.swift
+++ b/Sources/Kingfisher+Rx.swift
@@ -22,7 +22,9 @@ extension Reactive where Base == KingfisherWrapper<ImageView> {
                 case .success(let value):
                     single(.success(value.image))
                 case .failure(let error):
-                    single(.error(error))
+                    if !error.isTaskCancelledError {
+                        single(.error(error))
+                    }
                 }
             }
             

--- a/Sources/KingfisherErrorExtensions.swift
+++ b/Sources/KingfisherErrorExtensions.swift
@@ -1,0 +1,11 @@
+import Kingfisher
+
+extension KingfisherError {
+    var isTaskCancelledError: Bool {
+        if case .requestError(reason: .taskCancelled) = self {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/Sources/KingfisherManager+Rx.swift
+++ b/Sources/KingfisherManager+Rx.swift
@@ -19,7 +19,9 @@ extension Reactive where Base == KingfisherManager {
                 case .success(let value):
                     single(.success(value.image))
                 case .failure(let error):
-                    single(.error(error))
+                    if !error.isTaskCancelledError {
+                        single(.error(error))
+                    }
                 }
             }
 


### PR DESCRIPTION
Closes #20.

Upon cancelling a Kingfisher task, the Kingfisher library calls the completion block twice:
* once for the request timing out
* once for the task being cancelled

This causes issues in Rx because it detects a re-entrancy anomaly. I'm not actually sure if it causes a real issue given that the task is being cancelled from the stream being disposed of anyway, but it prints a scary message to the console and it's best to clean things up.

Important note: I don't have enough familiarity with the Kingfisher library to be confident that there's no time they would only send the task cancelled error _and_ not from us explicitly calling `task.cancel()`. If that were ever to happen, we would want to re-think this solution. 