### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Support for Swift Package Manager.
 
 ### Removed
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "RxKingfisher",
+    platforms: [
+        .macOS(.v10_12), .iOS(.v10), .tvOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "RxKingfisher",
+            targets: ["RxKingfisher"]
+        ),
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/ReactiveX/RxSwift.git",
+            from: "5.0.0"
+        ),
+        .package(
+            url: "https://github.com/onevcat/Kingfisher.git",
+            from: "5.0.0"
+        )
+    ],
+    targets: [
+        .target(
+            name: "RxKingfisher",
+            dependencies: ["RxSwift", "RxCocoa", "Kingfisher"],
+            path: "Sources"
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
This pull requests adds a Swift Package Manager `Package.swift` file so that this library can be imported using SPM in addition to CocoaPods.