### PR TITLE
Fix build error while using by SPM

### DIFF
--- a/Sources/RxKingfisher/Kingfisher+Rx.swift
+++ b/Sources/RxKingfisher/Kingfisher+Rx.swift
@@ -11,7 +11,7 @@ import RxSwift
 import Kingfisher
 
 extension KingfisherWrapper {
-    struct Rx {
+    public struct Rx {
         private let wrapper: KingfisherWrapper<KFCrossPlatformImageView>
         
         init(_ base: KingfisherWrapper<KFCrossPlatformImageView>) {
@@ -65,7 +65,7 @@ extension KingfisherWrapper {
 }
 
 extension KingfisherWrapper where Base == KFCrossPlatformImageView {
-    var rx: KingfisherWrapper.Rx {
+    public var rx: KingfisherWrapper.Rx {
         .init(self)
     }
 }


### PR DESCRIPTION
When I try to use RxKingfisher by SPM, I can't access kf.rx because it doesn't exposed to public. (It was ok with CocoaPods)